### PR TITLE
Add XHR header so Rails will give back JSON

### DIFF
--- a/app/assets/javascripts/bulletin.js
+++ b/app/assets/javascripts/bulletin.js
@@ -1,4 +1,7 @@
 var bulletinApp = angular.module('bulletinApp', ['ngResource']);
+bulletinApp.config(['$httpProvider', function ($httpProvider) {
+  $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+}]);
 
   bulletinApp.controller('PostsCtrl', ['$scope', 'Post', function($scope, Post) {
     $scope.welcome_text = 'Welcome to the bulletin board. LOSER.';


### PR DESCRIPTION
Rails ignores content negotiation when the Accept header includes `*/*`.
By adding the XHR header for Angular requests, it'll fix the behavior.

See https://github.com/rails/rails/issues/9940 and https://github.com/angular/angular.js/issues/1004
